### PR TITLE
fix: updated github icon redirect url

### DIFF
--- a/src/sitecomponents/Footer/index.js
+++ b/src/sitecomponents/Footer/index.js
@@ -42,7 +42,7 @@ const Footer = () => {
               </a>
             </li>
             <li>
-              <a className="category-link" href="https://github.com/layer5io/">
+              <a className="category-link" href="https://github.com/layer5io/recognition">
                 <img src={GithubIcon} alt="GitHub Icon" />
                 Github
               </a>


### PR DESCRIPTION
**Notes for Reviewers**

This PR updates the new GitHub icon redirect URL from  https://github.com/layer5io/ to https://github.com/layer5io/recognition




**[Signed commits](../blob/master/CONTRIBUTING.md#signing-off-on-commits-developer-certificate-of-origin)**
- [ ] Yes, I signed my commits.
 

<!--
Thank you for contributing to Meshery! 

Contributing Conventions:

1. Include descriptive PR titles with [<component-name>] prepended.
2. Build and test your changes before submitting a PR. 
3. Sign your commits

By following the community's contribution conventions upfront, the review process will 
be accelerated and your PR merged more quickly.
-->
