### PR TITLE
[site] Add Open Graph and Twitter Card social preview tags

### DIFF
--- a/gatsby-config.js
+++ b/gatsby-config.js
@@ -7,6 +7,9 @@ module.exports = {
     title: `Layer5 Recognition Program`,
     description: `Showcasing Your Achievements as a User and a Contributor`,
     siteUrl: `https://badges.layer5.io`,
+    social: {
+      twitter: `@layer5`,
+    },
   },
   plugins: [
     `gatsby-plugin-styled-components`,

--- a/gatsby-node.js
+++ b/gatsby-node.js
@@ -94,6 +94,8 @@ exports.createSchemaCustomization = ({ actions }) => {
   // blog posts are stored inside "content/blog" instead of returning an error
   createTypes(`
     type SiteSiteMetadata {
+      title: String
+      description: String
       author: Author
       siteUrl: String
       social: Social

--- a/src/pages/404.js
+++ b/src/pages/404.js
@@ -1,4 +1,5 @@
 import * as React from "react"
+import Seo from "../sitecomponents/SEO"
 
 const NotFoundPage = ({ location }) => {
   return (
@@ -9,6 +10,6 @@ const NotFoundPage = ({ location }) => {
   )
 }
 
-export const Head = () => <title>404: Not Found</title>
+export const Head = () => <Seo title="404: Not Found" pathname="/404" />
 
 export default NotFoundPage

--- a/src/pages/discussion-leaderboard.js
+++ b/src/pages/discussion-leaderboard.js
@@ -12,6 +12,7 @@ import {
 } from '../sitecomponents/index.style';
 import Navigation from '../sitecomponents/Navigation';
 import Header from '../sitecomponents/Leaderboard/Header';
+import Seo from '../sitecomponents/SEO';
 
 const LeaderBoard = () => {
   const [theme, toggleTheme] = useDarkMode();
@@ -38,11 +39,6 @@ const LeaderBoard = () => {
     theme === 'light' ? layer5LeaderboardLightMode : layer5LeaderboardDarkMode;
   return (
     <>
-      <title>Layer5 LeaderBoard</title>
-      <meta
-        name="description"
-        content="Showcasing Your Achievements as a User and a Contributor"
-      />
       <ThemeProvider theme={themeMode}>
         <GlobalStyle />
         <Navigation
@@ -66,3 +62,7 @@ const LeaderBoard = () => {
 };
 
 export default LeaderBoard;
+
+export const Head = () => (
+  <Seo title="Layer5 Leaderboard" pathname="/discussion-leaderboard" />
+);

--- a/src/pages/index.js
+++ b/src/pages/index.js
@@ -16,6 +16,7 @@ import recognitionLogo from '../assets/images/recognition-program.png';
 import recognitionBanner from '../assets/images/recognition-banner.png';
 import '../fonts.css';
 import GithubLogo from './githubLogo';
+import Seo from '../sitecomponents/SEO';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import layer5Logo from '../assets/images/layer5/layer5-badges.png';
 import layer5LogoLight from '../assets/images/layer5/layer5-badges-white.png';
@@ -218,11 +219,6 @@ const App = () => {
   // };
   return (
     <>
-      <title>Layer5 Recognition Program</title>
-      <meta
-        name="description"
-        content="Showcasing Your Achievements as a User and a Contributor"
-      />
       <QueryClientProvider client={queryClient}>
         <ThemeProvider theme={themeMode}>
           <GlobalStyle />
@@ -380,3 +376,5 @@ const App = () => {
 };
 
 export default App;
+
+export const Head = () => <Seo pathname="/" />;

--- a/src/sitecomponents/SEO/index.js
+++ b/src/sitecomponents/SEO/index.js
@@ -35,17 +35,22 @@ const Seo = ({ title, description, image, pathname, children }) => {
   const metadata = site.siteMetadata;
   const siteUrl = metadata.siteUrl.replace(/\/$/, '');
   // Gatsby serves pages with a trailing slash, so keep the canonical and
-  // `og:url` values in step with the URL that is actually shared.
+  // `og:url` values in step with the production URL that is actually shared.
   const path = (pathname || '/').replace(/\/?$/, '/');
 
   const seo = {
     title: title || metadata.title,
     description: description || metadata.description,
-    // Page routes need `withPrefix` for path-prefixed builds. Imported assets
-    // do not: webpack's publicPath already carries the prefix, so passing
-    // `defaultSocialImage` through `withPrefix` would apply it twice.
-    url: `${siteUrl}${withPrefix(path)}`,
-    image: `${siteUrl}${image || defaultSocialImage}`,
+    // Deliberately unprefixed. `pathPrefix` is only ever set by the PR preview
+    // workflow, which is an ephemeral deployment; production is served from the
+    // root of siteUrl. The canonical and og:url of a preview should therefore
+    // point at the production route, not at the preview path.
+    url: `${siteUrl}${path}`,
+    // Assets do need the prefix. An imported asset gets it from webpack's
+    // publicPath, so `defaultSocialImage` is already prefixed and must not be
+    // passed through `withPrefix` again; a caller-supplied path out of
+    // `static/` does not, so it goes through `withPrefix`.
+    image: `${siteUrl}${image ? withPrefix(image) : defaultSocialImage}`,
     twitter: metadata.social?.twitter,
   };
 

--- a/src/sitecomponents/SEO/index.js
+++ b/src/sitecomponents/SEO/index.js
@@ -1,5 +1,5 @@
 import React from 'react';
-import { useStaticQuery, graphql } from 'gatsby';
+import { useStaticQuery, graphql, withPrefix } from 'gatsby';
 import defaultSocialImage from '../../assets/images/recognition-banner.png';
 
 // Intrinsic dimensions of `defaultSocialImage`. Update alongside the image so
@@ -41,7 +41,10 @@ const Seo = ({ title, description, image, pathname, children }) => {
   const seo = {
     title: title || metadata.title,
     description: description || metadata.description,
-    url: `${siteUrl}${path}`,
+    // Page routes need `withPrefix` for path-prefixed builds. Imported assets
+    // do not: webpack's publicPath already carries the prefix, so passing
+    // `defaultSocialImage` through `withPrefix` would apply it twice.
+    url: `${siteUrl}${withPrefix(path)}`,
     image: `${siteUrl}${image || defaultSocialImage}`,
     twitter: metadata.social?.twitter,
   };

--- a/src/sitecomponents/SEO/index.js
+++ b/src/sitecomponents/SEO/index.js
@@ -1,0 +1,88 @@
+import React from 'react';
+import { useStaticQuery, graphql } from 'gatsby';
+import defaultSocialImage from '../../assets/images/recognition-banner.png';
+
+// Intrinsic dimensions of `defaultSocialImage`. Update alongside the image so
+// that crawlers can lay the card out before the image itself is fetched.
+const DEFAULT_SOCIAL_IMAGE_WIDTH = 3629;
+const DEFAULT_SOCIAL_IMAGE_HEIGHT = 1599;
+
+/**
+ * Renders the document's SEO metadata, including Open Graph and Twitter Card
+ * tags so that links to the site unfurl with a rich preview on social media,
+ * Slack, Discord and other community channels.
+ *
+ * Intended to be used from a page's `Head` export:
+ *
+ *   export const Head = () => <Seo pathname="/" />;
+ */
+const Seo = ({ title, description, image, pathname, children }) => {
+  const { site } = useStaticQuery(graphql`
+    query SeoMetadata {
+      site {
+        siteMetadata {
+          title
+          description
+          siteUrl
+          social {
+            twitter
+          }
+        }
+      }
+    }
+  `);
+
+  const metadata = site.siteMetadata;
+  const siteUrl = metadata.siteUrl.replace(/\/$/, '');
+  // Gatsby serves pages with a trailing slash, so keep the canonical and
+  // `og:url` values in step with the URL that is actually shared.
+  const path = (pathname || '/').replace(/\/?$/, '/');
+
+  const seo = {
+    title: title || metadata.title,
+    description: description || metadata.description,
+    url: `${siteUrl}${path}`,
+    image: `${siteUrl}${image || defaultSocialImage}`,
+    twitter: metadata.social?.twitter,
+  };
+
+  return (
+    <>
+      <title>{seo.title}</title>
+      <meta name="description" content={seo.description} />
+      <link rel="canonical" href={seo.url} />
+
+      <meta property="og:type" content="website" />
+      <meta property="og:site_name" content={metadata.title} />
+      <meta property="og:title" content={seo.title} />
+      <meta property="og:description" content={seo.description} />
+      <meta property="og:url" content={seo.url} />
+      <meta property="og:image" content={seo.image} />
+      <meta property="og:image:alt" content={seo.title} />
+      {!image && (
+        <meta
+          property="og:image:width"
+          content={DEFAULT_SOCIAL_IMAGE_WIDTH}
+        />
+      )}
+      {!image && (
+        <meta
+          property="og:image:height"
+          content={DEFAULT_SOCIAL_IMAGE_HEIGHT}
+        />
+      )}
+
+      <meta name="twitter:card" content="summary_large_image" />
+      <meta name="twitter:title" content={seo.title} />
+      <meta name="twitter:description" content={seo.description} />
+      <meta name="twitter:image" content={seo.image} />
+      <meta name="twitter:image:alt" content={seo.title} />
+      {seo.twitter && <meta name="twitter:site" content={seo.twitter} />}
+      {seo.twitter && <meta name="twitter:creator" content={seo.twitter} />}
+
+      {children}
+    </>
+  );
+};
+
+export default Seo;


### PR DESCRIPTION
**Notes for Reviewers**

This PR fixes #111

`badges.layer5.io` emitted no Open Graph or Twitter Card metadata, so sharing the URL produced a bare link with no preview card.

The `title`/`description` tags that `index.js` and `discussion-leaderboard.js` did render were placed in the component body rather than in `<head>`, so under React 18 they never reached the document head at all — only `404.js` used Gatsby's `Head` API correctly.

**What changed**

- **New `src/sitecomponents/SEO/index.js`** — a shared `Seo` component rendering `title`, `description`, `link rel=canonical`, the Open Graph set (`og:type`, `og:site_name`, `og:title`, `og:description`, `og:url`, `og:image`, `og:image:alt`, `og:image:width/height`) and the Twitter Card set (`twitter:card=summary_large_image`, `twitter:title`, `twitter:description`, `twitter:image`, `twitter:image:alt`, `twitter:site`, `twitter:creator`). It accepts per-page `title` / `description` / `image` / `pathname` overrides and falls back to `siteMetadata`.
- **Wired into all three pages** via the `Head` export: `index.js`, `discussion-leaderboard.js`, `404.js`. The misplaced in-body `<title>`/`<meta>` were removed.
- **Card image** — the existing `src/assets/images/recognition-banner.png` suggested in the issue. It is referenced through the normal webpack asset import rather than duplicated into `static/`, so no new binary is added to the repo, and the tag carries the fully-qualified `https://badges.layer5.io/...` URL that crawlers require.
- **`gatsby-config.js`** — added `siteMetadata.social.twitter` (`@layer5`) to populate `twitter:site` / `twitter:creator`. The `Social` type was already declared in `gatsby-node.js` but had no value behind it.
- **`gatsby-node.js`** — declared `title` and `description` on `SiteSiteMetadata`. That type is explicitly created via `createTypes`, which disables inference, so the two fields were not queryable from GraphQL despite being set in `gatsby-config.js`.

**Verification**

`npm run build` succeeds, and the generated HTML carries the tags in `<head>` on every page:

```
public/index.html
  <meta property="og:title"       content="Layer5 Recognition Program">
  <meta property="og:url"         content="https://badges.layer5.io/">
  <meta property="og:image"       content="https://badges.layer5.io/static/recognition-banner-<hash>.png">
  <meta name="twitter:card"       content="summary_large_image">
  <meta name="twitter:image"      content="https://badges.layer5.io/static/recognition-banner-<hash>.png">
  <link rel="canonical"           href="https://badges.layer5.io/">
```

`/discussion-leaderboard/` and `/404/` get the same set with their own titles and canonical URLs. No stray `title`/`meta` remain in `<body>`.

Note: building locally also required `@mui/icons-material`, `@mui/material` and `xstate`, which `@sistent/sistent` and `mui-datatables` need but which are not declared in `package.json`. That is pre-existing and unrelated to this change, so it is left alone here — happy to open a separate issue if useful.

**Follow-up worth considering:** the banner is 3629×1599 and ~1.8 MB. Every major platform will render it, but some unfurlers (WhatsApp in particular) skip images over a few hundred KB. A purpose-built 1200×630 card would unfurl everywhere; that is an asset decision for the design team, so I did not add one here.

**[Signed commits](../blob/master/CONTRIBUTING.md#signing-off-on-commits-developer-certificate-of-origin)**
- [x] Yes, I signed my commits.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added consistent SEO metadata for the homepage, 404 page, and discussion leaderboard.
  * Added support for page titles, descriptions, canonical URLs, Open Graph tags, and Twitter Card previews.
  * Added support for custom social images and page paths.
  * Added Layer5’s Twitter handle to eligible social sharing metadata.
  * Added fallback metadata and a default social image when page-specific values are unavailable.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->